### PR TITLE
捉虫

### DIFF
--- a/luci-app-gowebdav/luasrc/view/gowebdav/gowebdav_status.htm
+++ b/luci-app-gowebdav/luasrc/view/gowebdav/gowebdav_status.htm
@@ -14,7 +14,7 @@ XHR.poll(1, '<%=url([[admin]], [[nas]], [[gowebdav]], [[status]])%>', null,
 );
 
 function openwebui() {
-	var url = window.location.host+":<%=luci.sys.exec("uci -q get gowebdav.config.listen_port"):gsub("^%s*(.-)%s*$", "%1")%>";
+	var url = window.location.hostname+":<%=luci.sys.exec("uci -q get gowebdav.config.listen_port"):gsub("^%s*(.-)%s*$", "%1")%>";
 	window.open('http://'+url,'target','');
 };
 //]]>


### PR DESCRIPTION
第17行的host应该改为hostname,不然若设置界面改了端口，点击这个界面就会打开 （地址：端口:端口），报错。。